### PR TITLE
Added Recieved Connection Request api

### DIFF
--- a/Controllers/RecievedConnectionRequest.js
+++ b/Controllers/RecievedConnectionRequest.js
@@ -1,0 +1,24 @@
+const { status } = require("express/lib/response");
+const ConnectionModel = require("../Model/ConnectionModel");
+
+//function of this api is to show all the requests to the user which has status interested
+
+async function RecievedConnectionRequest(req, res) {
+  try {
+    const loggedInUser = req.user._id;
+
+    const connectionRequest = await ConnectionModel.find({
+      receiverUserId: loggedInUser,
+      status: "interested",
+    })
+      .populate("senderUserId", ["name", "email"])
+      .select("-createdAt -updatedAt -receiverUserId -_id");
+
+    res.status(200).json({ success: true, data: connectionRequest });
+  } catch (err) {
+    console.log(err.message);
+    res.status(500).json({ success: false, message: "Internal server error" });
+  }
+}
+
+module.exports = RecievedConnectionRequest;

--- a/Routes/routes.js
+++ b/Routes/routes.js
@@ -12,6 +12,7 @@ const {
 } = require("../Controllers/updateUserInfo");
 
 const recievingRequest = require("../Controllers/recievingRequest");
+const RecievedConnectionRequest = require("../Controllers/recievedConnectionRequest");
 
 router.post("/signup", signup);
 router.post("/login", login);
@@ -32,6 +33,11 @@ router.post(
   "/RecievingConnectionRequest/:status/:requestId",
   AuthMiddlewear,
   recievingRequest
+);
+router.post(
+  "/RecievedConnectionRequest",
+  AuthMiddlewear,
+  RecievedConnectionRequest
 );
 
 module.exports = router;


### PR DESCRIPTION
The RecievedConnectionRequest API is used to fetch all the connection requests that the currently logged-in user has received and that are in the “interested” status (i.e., pending or awaiting response).