### PR TITLE
Added feed API with connection request filtering

### DIFF
--- a/Controllers/feed.js
+++ b/Controllers/feed.js
@@ -1,0 +1,47 @@
+const ConnectionModel = require("../Model/ConnectionModel");
+const userModel = require("../Model/userModel");
+async function feed(req, res) {
+  try {
+    const loggedInUser = req.user._id;
+
+    const page = parseInt(req.query.params) || 1;
+    const limit = parseInt(req.query.params) || 10;
+
+    if (limit > 10) {
+      limit = 10;
+    }
+
+    const skip = (page - 1) * limit;
+
+    const connectionRequest = await ConnectionModel.find({
+      $or: [{ receiverUserId: loggedInUser }, { senderUserId: loggedInUser }],
+    })
+      .select("senderUserId recieverUserId")
+      .populate("senderUserId", ["name"])
+      .populate("receiverUserId", ["name"]);
+
+    const hideUserFromFeed = new Set();
+
+    for (let i = 0; i < connectionRequest.length; i++) {
+      hideUserFromFeed.add(connectionRequest[i].receiverUserId);
+      hideUserFromFeed.add(connectionRequest[i].senderUserId);
+    }
+
+    const feed = await userModel
+      .find({
+        $and: [
+          { _id: { $nin: Array.from(hideUserFromFeed) } },
+          { _id: { $ne: loggedInUser._id } },
+        ],
+      })
+      .select("name email")
+      .skip(skip)
+      .limit(limit);
+
+    res.send(feed);
+  } catch (err) {
+    console.log(err.message);
+    res.status(500).send("Server Error");
+  }
+}
+module.exports = feed;

--- a/Routes/routes.js
+++ b/Routes/routes.js
@@ -13,6 +13,7 @@ const {
 
 const recievingRequest = require("../Controllers/recievingRequest");
 const Connections = require("../Controllers/Connections");
+const feed = require("../Controllers/feed");
 
 router.post("/signup", signup);
 router.post("/login", login);
@@ -41,5 +42,6 @@ router.post(
 // );
 
 router.post("/Connections", AuthMiddlewear, Connections);
+router.post("/feed", AuthMiddlewear, feed);
 
 module.exports = router;


### PR DESCRIPTION
The Feed API is designed to show users a filtered list of potential connections while excluding certain users based on the user’s previous interactions. This API allows logged-in users to see other users who have not been interacted with previously.

Key Functionalities:

	1.	Filter Users:
	•	The API hides users to whom the logged-in user has already sent or received a connection request.
	•	The API also ensures that the logged-in user’s own profile is not displayed in their feed.
	2.	Pagination Support:
	•	The API includes pagination to limit the number of users shown per request. Users can navigate through the pages to see more profiles.